### PR TITLE
feat: Argument `instructions` allows one to prepend instructions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sbgjackets
 Type: Package
 Title: Utilities for Small Box Game Jackets
-Version: 0.1.0-2
+Version: 0.1.0-3
 Authors@R: c(person("Trevor L.", "Davis", role=c("aut", "cre"),
                      email="trevor.l.davis@gmail.com",
                      comment = c(ORCID = "0000-0001-6341-4639")),
@@ -23,7 +23,7 @@ Imports:
     magick,
     marquee,
     piecepackr,
-    pnpmisc (>= 0.1.0-15),
+    pnpmisc (>= 0.1.0-16),
     ppdf,
     qpdf,
     rlang,

--- a/R/dominoes.r
+++ b/R/dominoes.r
@@ -6,11 +6,13 @@
 #' @param output Output file name.  Defaults to `tempfile(fileext = ".pdf")`.
 #' @param ... Should be empty.
 #' @inheritParams pnpmisc::pdf_create_jacket
+#' @param instructions If `TRUE` then prepend instructions on how to make the jacket to the beginning of the pdf
 #' @return The output file name invisibly.  As a side effect creates a pdf file.
 #' @rdname sbgj_dominoes
 #' @export
 sbgj_dominoes_all <- function(output = NULL, ...,
-                              paper = c("letter", "a4")) {
+                              paper = c("letter", "a4"),
+                              instructions = TRUE) {
     check_dots_empty()
     assert_runtime_dependencies()
 
@@ -22,6 +24,11 @@ sbgj_dominoes_all <- function(output = NULL, ...,
                                "Double-Nine Dominoes",
                                "Double-Twelve Dominoes"),
                      page = c(1L, 3L, 5L))
+    if (isTRUE(instructions)) {
+        bmi <- data.frame(title = "Instructions", page = 1L)
+        bm$page <- bm$page + 2L
+        bm <- rbind(bmi, bm)
+    }
 
     xmp <- xmp(creator = "Trevor L. Davis",
                date_created = "2025",
@@ -32,8 +39,10 @@ sbgj_dominoes_all <- function(output = NULL, ...,
     d9d <- sbgj_dominoes_double9(paper = paper)
     d12d <- sbgj_dominoes_double12(paper = paper)
     output_c <- tempfile(fileext = ".pdf")
-
-    qpdf::pdf_combine(c(d6d, d9d, d12d), output_c) |>
+    qpdf::pdf_combine(c(d6d, d9d, d12d), output_c)
+    if (instructions)
+        prepend_instructions(output_c, paper = paper)
+    output_c |>
         pnpmisc::pdf_set_bookmarks(bookmarks = bm) |>
         pnpmisc::pdf_set_xmp(xmp = xmp) |>
         pnpmisc::pdf_set_docinfo(docinfo = as_docinfo(xmp)) |>
@@ -47,7 +56,8 @@ sbgj_dominoes_all <- function(output = NULL, ...,
 #' @rdname sbgj_dominoes
 #' @export
 sbgj_dominoes_double6 <- function(output = NULL, ...,
-                                  paper = c("letter", "a4")) {
+                                  paper = c("letter", "a4"),
+                                  instructions = FALSE) {
     check_dots_empty()
     assert_runtime_dependencies()
 
@@ -88,6 +98,8 @@ sbgj_dominoes_double6 <- function(output = NULL, ...,
 
     output <- pdf_create_jacket(output = output, front = front, back = back,
                                 spine = spine, inner = inner, paper = paper)
+    if (instructions)
+        prepend_instructions(output, paper = paper)
     set_xmp(xmp, output)
     set_docinfo(as_docinfo(xmp), output)
     invisible(output)
@@ -96,7 +108,8 @@ sbgj_dominoes_double6 <- function(output = NULL, ...,
 #' @rdname sbgj_dominoes
 #' @export
 sbgj_dominoes_double9 <- function(output = NULL, ...,
-                                  paper = c("letter", "a4")) {
+                                  paper = c("letter", "a4"),
+                                  instructions = FALSE) {
     check_dots_empty()
     assert_runtime_dependencies()
 
@@ -164,6 +177,8 @@ sbgj_dominoes_double9 <- function(output = NULL, ...,
 
     output <- pdf_create_jacket(output = output, front = front, back = back,
                                 spine = spine, inner = inner, paper = paper)
+    if (instructions)
+        prepend_instructions(output, paper = paper)
     set_xmp(xmp, output)
     set_docinfo(as_docinfo(xmp), output)
     invisible(output)
@@ -172,7 +187,8 @@ sbgj_dominoes_double9 <- function(output = NULL, ...,
 #' @rdname sbgj_dominoes
 #' @export
 sbgj_dominoes_double12 <- function(output = NULL, ...,
-                                   paper = c("letter", "a4")) {
+                                   paper = c("letter", "a4"),
+                                   instructions = FALSE) {
     check_dots_empty()
     assert_runtime_dependencies()
 
@@ -236,6 +252,8 @@ sbgj_dominoes_double12 <- function(output = NULL, ...,
 
     output <- pdf_create_jacket(output = output, front = front, back = back,
                                 spine = spine, inner = inner, paper = paper)
+    if (instructions)
+        prepend_instructions(output, paper = paper)
     set_xmp(xmp, output)
     set_docinfo(as_docinfo(xmp), output)
     invisible(output)

--- a/R/looney_pyramids.r
+++ b/R/looney_pyramids.r
@@ -14,12 +14,14 @@
 #'
 #' @param output Output file name.  Defaults to `tempfile(fileext = ".pdf")`.
 #' @param ... Should be empty.
+#' @inheritParams sbgj_dominoes_all
 #' @inheritParams pnpmisc::pdf_create_jacket
 #' @return The output file name invisibly.  As a side effect creates a pdf file.
 #' @rdname sbgj_looney
 #' @export
 sbgj_looney_pyramids_all <- function(output = NULL, ...,
-                              paper = c("letter", "a4")) {
+                                     paper = c("letter", "a4"),
+                                     instructions = TRUE) {
     check_dots_empty()
     assert_runtime_dependencies()
 
@@ -36,6 +38,11 @@ sbgj_looney_pyramids_all <- function(output = NULL, ...,
                                "Nomids",
                                "Nomids (Custom Back)"),
                      page = seq.int(1L, by = 2L, length.out = 8L))
+    if (isTRUE(instructions)) {
+        bmi <- data.frame(title = "Instructions", page = 1L)
+        bm$page <- bm$page + 2L
+        bm <- rbind(bmi, bm)
+    }
 
     xmp <- xmp(creator = "Trevor L. Davis",
                title = "Looney Pyramids Small Box Game Jackets")
@@ -49,8 +56,10 @@ sbgj_looney_pyramids_all <- function(output = NULL, ...,
     nomids1 <- sbgj_nomids(paper = paper)
     nomids2 <- sbgj_nomids(paper = paper, custom = TRUE)
     output_c <- tempfile(fileext = ".pdf")
-
-    qpdf::pdf_combine(c(lp, hm, id, jx, mc1, mc2, nomids1, nomids2), output_c) |>
+    qpdf::pdf_combine(c(lp, hm, id, jx, mc1, mc2, nomids1, nomids2), output_c)
+    if (instructions)
+        prepend_instructions(output_c, paper = paper)
+    output_c |>
         pnpmisc::pdf_set_bookmarks(bookmarks = bm) |>
         pnpmisc::pdf_set_xmp(xmp = xmp) |>
         pnpmisc::pdf_set_docinfo(docinfo = as_docinfo(xmp)) |>
@@ -64,7 +73,8 @@ sbgj_looney_pyramids_all <- function(output = NULL, ...,
 #' @rdname sbgj_looney
 #' @export
 sbgj_looney_pyramids <- function(output = NULL, ...,
-                                 paper = c("letter", "a4")) {
+                                 paper = c("letter", "a4"),
+                                 instructions = FALSE) {
     check_dots_empty()
     assert_runtime_dependencies()
 
@@ -194,6 +204,8 @@ sbgj_looney_pyramids <- function(output = NULL, ...,
 
     output <- pdf_create_jacket(output = output, front = front, back = back,
                                 spine = spine, inner = inner, paper = paper)
+    if (instructions)
+        prepend_instructions(output, paper = paper)
 
     set_xmp(xmp, output)
     set_docinfo(as_docinfo(xmp), output)
@@ -283,7 +295,8 @@ load_pyramid_badges <- function() {
 #' @rdname sbgj_looney
 #' @export
 sbgj_homeworlds <- function(output = NULL, ...,
-                            paper = c("letter", "a4")) {
+                            paper = c("letter", "a4"),
+                            instructions = FALSE) {
     check_dots_empty()
     assert_runtime_dependencies()
 
@@ -341,6 +354,8 @@ sbgj_homeworlds <- function(output = NULL, ...,
 
     output <- pdf_create_jacket(output = output, front = front, back = back,
                                 spine = spine, inner = inner, paper = paper)
+    if (instructions)
+        prepend_instructions(output, paper = paper)
 
     set_xmp(xmp, output)
     set_docinfo(as_docinfo(xmp), output)
@@ -350,7 +365,8 @@ sbgj_homeworlds <- function(output = NULL, ...,
 #' @rdname sbgj_looney
 #' @export
 sbgj_ice_duo <- function(output = NULL, ...,
-                         paper = c("letter", "a4")) {
+                         paper = c("letter", "a4"),
+                         instructions = FALSE) {
     check_dots_empty()
     assert_runtime_dependencies()
 
@@ -408,6 +424,8 @@ sbgj_ice_duo <- function(output = NULL, ...,
 
     output <- pdf_create_jacket(output = output, front = front, back = back,
                                 spine = spine, inner = inner, paper = paper)
+    if (instructions)
+        prepend_instructions(output, paper = paper)
 
     set_xmp(xmp, output)
     set_docinfo(as_docinfo(xmp), output)
@@ -417,7 +435,8 @@ sbgj_ice_duo <- function(output = NULL, ...,
 #' @rdname sbgj_looney
 #' @export
 sbgj_jinxx <- function(output = NULL, ...,
-                       paper = c("letter", "a4")) {
+                       paper = c("letter", "a4"),
+                       instructions = FALSE) {
     check_dots_empty()
     assert_runtime_dependencies()
 
@@ -475,6 +494,8 @@ sbgj_jinxx <- function(output = NULL, ...,
 
     output <- pdf_create_jacket(output = output, front = front, back = back,
                                 spine = spine, inner = inner, paper = paper)
+    if (instructions)
+        prepend_instructions(output, paper = paper)
 
     set_xmp(xmp, output)
     set_docinfo(as_docinfo(xmp), output)
@@ -487,7 +508,8 @@ sbgj_jinxx <- function(output = NULL, ...,
 #' @export
 sbgj_martian_chess <- function(output = NULL, ...,
                                silver = FALSE,
-                               paper = c("letter", "a4")) {
+                               paper = c("letter", "a4"),
+                               instructions = FALSE) {
     check_dots_empty()
     assert_runtime_dependencies()
 
@@ -569,6 +591,8 @@ sbgj_martian_chess <- function(output = NULL, ...,
 
     output <- pdf_create_jacket(output = output, front = front, back = back,
                                 spine = spine, inner = inner, paper = paper)
+    if (instructions)
+        prepend_instructions(output, paper = paper)
 
     set_xmp(xmp, output)
     set_docinfo(as_docinfo(xmp), output)
@@ -580,6 +604,7 @@ sbgj_martian_chess <- function(output = NULL, ...,
 #' @export
 sbgj_nomids <- function(output = NULL, ...,
                         paper = c("letter", "a4"),
+                        instructions = FALSE,
                         custom = FALSE) {
     check_dots_empty()
     assert_runtime_dependencies()
@@ -678,6 +703,8 @@ sbgj_nomids <- function(output = NULL, ...,
 
     output <- pdf_create_jacket(output = output, front = front, back = back,
                                 spine = spine, inner = inner, paper = paper)
+    if (instructions)
+        prepend_instructions(output, paper = paper)
 
     set_xmp(xmp, output)
     set_docinfo(as_docinfo(xmp), output)

--- a/README.Rmd
+++ b/README.Rmd
@@ -74,7 +74,8 @@ This package also provides functions that locally create SBG jackets pdfs for a 
 | Quantity | Over 1,400 pre-made jackets | 9 pre-made jackets |
 | Process | Made in Microsoft Publisher with a template | Made in `R` with `pnpmisc::pdf_create_jacket()` |
 | Spine Font | Calibri (proprietary) | Carlito (libre font, metrically compatible with Calibri) |
-| Spine Icons | Proprietary icons that each vary in color and style | Libre icons from game-icons.net that don't vary (but chosen to not be too dissimilar from Boardgame Barrio's icons) |
+| Spine Text Color | Spine text is always white | Spine text may be other colors (e.g. to match cover text color) |
+| Spine Icons | Proprietary icons whose style and backround color can each vary between three levels (i.e. green, orange, or red) | Libre icons from game-icons.net that don't vary in style and aren't color-coded (but the icons are chosen to not be too dissimilar from Boardgame Barrio's icons) |
 | License | Always "For Personal Use Only" | Sometimes "For Personal Use Only" but sometimes available under various Creative Commons licenses when the image licenses allow |
 | Credits | | List of credits to go on inside cover |
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ This package also provides functions that locally create SBG jackets pdfs for a 
 | Quantity | Over 1,400 pre-made jackets | 9 pre-made jackets |
 | Process | Made in Microsoft Publisher with a template | Made in `R` with `pnpmisc::pdf_create_jacket()` |
 | Spine Font | Calibri (proprietary) | Carlito (libre font, metrically compatible with Calibri) |
-| Spine Icons | Proprietary icons that each vary in color and style | Libre icons from game-icons.net that don't vary (but chosen to not be too dissimilar from Boardgame Barrio's icons) |
+| Spine Text Color | Spine text is always white | Spine text may be other colors (e.g. to match cover text color) |
+| Spine Icons | Proprietary icons whose style and backround color can each vary between three levels (i.e. green, orange, or red) | Libre icons from game-icons.net that don't vary in style and aren't color-coded (but the icons are chosen to not be too dissimilar from Boardgame Barrio's icons) |
 | License | Always "For Personal Use Only" | Sometimes "For Personal Use Only" but sometimes available under various Creative Commons licenses when the image licenses allow |
 | Credits | | List of credits to go on inside cover |
 
@@ -86,6 +87,7 @@ This package also provides functions that locally create SBG jackets pdfs for a 
 * [Boardgame Barrio's Small Box Game Jackets](https://sites.google.com/view/boardgamebarrio)
 * [Carlito font](https://fonts.google.com/specimen/Carlito)
 * [Game-icons.net](https://game-icons.net)
-* [Origami Masu Box](https://www.paperkawaii.com/origami-photo-tutorials/masu-box/) and [Origami Masu Box Divider](https://www.paperkawaii.com/origami-photo-tutorials/masu-box-divider/)
+* [Origami Masu Box](https://www.paperkawaii.com/origami-photo-tutorials/masu-box/) and [Origami Masu Box Divider](https://www.paperkawaii.com/origami-photo-tutorials/masu-box-divider/) (6"x6" paper)
+* [Origami Baggi Box](http://www.origami-instructions.com/origami-baggi-box.html)
 * [Photo Storage Board Game Insert Collection](https://www.reddit.com/r/boardgames/comments/vs6b6q/photo_storage_board_game_insert_collection/)
 * [Guide to Organizing Small Box Games](https://web.archive.org/web/20220711005902/https://www.kenkuhn.me/l/guide-to-organizing-small-box-games/)

--- a/man/sbgj_dominoes.Rd
+++ b/man/sbgj_dominoes.Rd
@@ -7,13 +7,33 @@
 \alias{sbgj_dominoes_double12}
 \title{Create SBG Jacket for Dominoes}
 \usage{
-sbgj_dominoes_all(output = NULL, ..., paper = c("letter", "a4"))
+sbgj_dominoes_all(
+  output = NULL,
+  ...,
+  paper = c("letter", "a4"),
+  instructions = TRUE
+)
 
-sbgj_dominoes_double6(output = NULL, ..., paper = c("letter", "a4"))
+sbgj_dominoes_double6(
+  output = NULL,
+  ...,
+  paper = c("letter", "a4"),
+  instructions = FALSE
+)
 
-sbgj_dominoes_double9(output = NULL, ..., paper = c("letter", "a4"))
+sbgj_dominoes_double9(
+  output = NULL,
+  ...,
+  paper = c("letter", "a4"),
+  instructions = FALSE
+)
 
-sbgj_dominoes_double12(output = NULL, ..., paper = c("letter", "a4"))
+sbgj_dominoes_double12(
+  output = NULL,
+  ...,
+  paper = c("letter", "a4"),
+  instructions = FALSE
+)
 }
 \arguments{
 \item{output}{Output file name.  Defaults to \code{tempfile(fileext = ".pdf")}.}
@@ -21,6 +41,8 @@ sbgj_dominoes_double12(output = NULL, ..., paper = c("letter", "a4"))
 \item{...}{Should be empty.}
 
 \item{paper}{Paper size.  Either "letter", "a4", or "special".}
+
+\item{instructions}{If \code{TRUE} then prepend instructions on how to make the jacket to the beginning of the pdf}
 }
 \value{
 The output file name invisibly.  As a side effect creates a pdf file.

--- a/man/sbgj_looney.Rd
+++ b/man/sbgj_looney.Rd
@@ -10,24 +10,51 @@
 \alias{sbgj_nomids}
 \title{Create SBG Jacket for Looney Pyramids}
 \usage{
-sbgj_looney_pyramids_all(output = NULL, ..., paper = c("letter", "a4"))
+sbgj_looney_pyramids_all(
+  output = NULL,
+  ...,
+  paper = c("letter", "a4"),
+  instructions = TRUE
+)
 
-sbgj_looney_pyramids(output = NULL, ..., paper = c("letter", "a4"))
+sbgj_looney_pyramids(
+  output = NULL,
+  ...,
+  paper = c("letter", "a4"),
+  instructions = FALSE
+)
 
-sbgj_homeworlds(output = NULL, ..., paper = c("letter", "a4"))
+sbgj_homeworlds(
+  output = NULL,
+  ...,
+  paper = c("letter", "a4"),
+  instructions = FALSE
+)
 
-sbgj_ice_duo(output = NULL, ..., paper = c("letter", "a4"))
+sbgj_ice_duo(
+  output = NULL,
+  ...,
+  paper = c("letter", "a4"),
+  instructions = FALSE
+)
 
-sbgj_jinxx(output = NULL, ..., paper = c("letter", "a4"))
+sbgj_jinxx(output = NULL, ..., paper = c("letter", "a4"), instructions = FALSE)
 
 sbgj_martian_chess(
   output = NULL,
   ...,
   silver = FALSE,
-  paper = c("letter", "a4")
+  paper = c("letter", "a4"),
+  instructions = FALSE
 )
 
-sbgj_nomids(output = NULL, ..., paper = c("letter", "a4"), custom = FALSE)
+sbgj_nomids(
+  output = NULL,
+  ...,
+  paper = c("letter", "a4"),
+  instructions = FALSE,
+  custom = FALSE
+)
 }
 \arguments{
 \item{output}{Output file name.  Defaults to \code{tempfile(fileext = ".pdf")}.}
@@ -35,6 +62,8 @@ sbgj_nomids(output = NULL, ..., paper = c("letter", "a4"), custom = FALSE)
 \item{...}{Should be left empty.}
 
 \item{paper}{Paper size.  Either "letter", "a4", or "special".}
+
+\item{instructions}{If \code{TRUE} then prepend instructions on how to make the jacket to the beginning of the pdf}
 
 \item{silver}{If \code{TRUE} make jacket for silver Martian Chess.}
 


### PR DESCRIPTION
* Argument `instructions` prepends a page of instructions to beginning of pdf files.
* Uses (pnp) `pnpmisc::pdf_create_jacket_instructions()`